### PR TITLE
Feature/extensibility

### DIFF
--- a/gh-pages-src/main.js
+++ b/gh-pages-src/main.js
@@ -27,6 +27,5 @@ Vue.config.productionTip = false
 new Vue({
   el: '#app',
   router,
-  vuetify: new Vuetify(),
   render: h => h(App)
 })

--- a/package.json
+++ b/package.json
@@ -47,8 +47,10 @@
     "tslint-config-standard": "^8.0.1",
     "typescript": "^3.3.3333",
     "vue": "^2.5.17",
+    "vue-analytics": "^5.17.0",
     "vue-router": "^3.0.1",
-    "vue-template-compiler": "^2.5.17"
+    "vue-template-compiler": "^2.5.17",
+    "vuetify": "^1.5.14"
   },
   "browserslist": [
     "> 0.3%",

--- a/src/component.vue
+++ b/src/component.vue
@@ -323,7 +323,7 @@ export default {
     },
     // ставит выбраный элемент по значению
     setSelectedItemByValue () {
-      if (!this.items.length) {
+      if (!this.getItems.length) {
         this.selectedItem = null
 
         return

--- a/src/computed.js
+++ b/src/computed.js
@@ -1,10 +1,15 @@
 export default {
-  itemsComputed () {
+  getItems () {
     let items = this.items
 
-    if (typeof this.items === 'string') {
+    if (typeof items === 'string') {
       items = JSON.parse(this.items)
     }
+
+    return items
+  },
+  itemsComputed () {
+    let items = this.getItems
 
     return this.filteredBySearchItems(items)
   },

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@ import '~/styles/main.styl'
 import component from '~/component.vue'
 import EventEmitter from '~/eventEmitter'
 
-export default new Singelton()
+export default new Singleton()
 export {
   EventEmitter,
   component,
@@ -10,7 +10,7 @@ export {
   component as VueCoolSelect
 }
 
-function Singelton () {
+function Singleton () {
   const self = this
 
   self.themes = ['bootstrap', 'material-design']

--- a/yarn.lock
+++ b/yarn.lock
@@ -12617,6 +12617,11 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
+vue-analytics@^5.17.0:
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/vue-analytics/-/vue-analytics-5.17.0.tgz#c9530b82b9b4acd111c9cba7d249adf4089746b3"
+  integrity sha512-1Cn/v06cGjmGDfRlG2hc0RF0sc2rNC88shOeLGNIlllSFv5GDZ9kLXGTPB9z9I+WyvFewyUONPIdQnpOls6h6w==
+
 vue-eslint-parser@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz#c268c96c6d94cfe3d938a5f7593959b0ca3360d1"
@@ -12691,6 +12696,11 @@ vue@^2.5.17:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.8.tgz#f21cbc536bfc14f7d1d792a137bb12f69e60ea91"
   integrity sha512-+vp9lEC2Kt3yom673pzg1J7T1NVGuGzO9j8Wxno+rQN2WYVBX2pyo/RGQ3fXCLh2Pk76Skw/laAPCuBuEQ4diw==
+
+vuetify@^1.5.14:
+  version "1.5.14"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-1.5.14.tgz#ff67d0b8a398be5297da159b6cd1b31f4d2898b8"
+  integrity sha512-7iM+TfghR/wu/Gl+k37lKr0N8Ddr6SxzqHtoK1dIyHgCH6SJRkpaXPw2MC5/FsAg9aUDJbYNWrzSeu5eHw+Q/w==
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Added a `getItems` computed property. As a default, it returns the `items` prop. However, it allows greater latitude in extending the component that I believe was not possible previously.  The rationale is as follows: Iwas trying to extend the component to make a country picker. To do that, I had to "fix" the `items` prop by passing a list of countries. That works, sort of (actually, only by overriding the prop with a default value, so it's not quite perfect). But when trying to introduce support for i18n, then I couldn't find a way to make it work. I would have had to mutate the prop, which is not possiblein vue.js. 

With this fix, I can simply override the `getItems` computed method. The `items` prop can be overridden as 'not required', and ignored if supplied. 